### PR TITLE
Make the show/hide password button explicitly as button type

### DIFF
--- a/client/src/components/ui/Input/Input.tsx
+++ b/client/src/components/ui/Input/Input.tsx
@@ -40,7 +40,7 @@ export default function Input({ label, error, id, className, ...attributes }: In
         {...restAttributes}
       />
       {isPasswordField && (
-        <button className="text-white absolute right-2 bottom-2" onClick={togglePasswordVisible}>
+        <button className="text-white absolute right-2 bottom-2" onClick={togglePasswordVisible} type="button">
           {isPasswordVisible ? <VscEyeClosed size={22} /> : <VscEye size={22} />}
         </button>
       )}


### PR DESCRIPTION
This fixes the glitch when you submit the form by pressing Enter key. Instead of submitting the form, it would toggle the show password on and off on Enter press.

That is not what we want, we want to submit the form on Enter press, which is what happens now.