### PR TITLE
Disable scrolling when the backdrop is visible

### DIFF
--- a/client/src/components/ui/Backdrop/Backdrop.tsx
+++ b/client/src/components/ui/Backdrop/Backdrop.tsx
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 interface BackdropProps {
   /**
    * Handles when user clicks on backdrop - it should close the side panel.
@@ -7,6 +9,16 @@ interface BackdropProps {
 }
 
 export default function Backdrop({ handleOnClick, isVisible }: BackdropProps) {
+  React.useEffect(() => {
+    if (isVisible) document.body.style.overflow = 'hidden';
+    else document.body.style.overflow = '';
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isVisible]);
+
+
   return (
     <div
       onClick={handleOnClick}

--- a/client/src/components/ui/ConfirmModal/ConfirmModal.tsx
+++ b/client/src/components/ui/ConfirmModal/ConfirmModal.tsx
@@ -18,10 +18,10 @@ export default function ConfirmModal({
   if (!isOpen) return null;
 
   return (
-    <>
+    <div className="fixed inset-0 flex justify-center items-center">
       <Backdrop handleOnClick={onCancel} isVisible={isOpen} />
-      <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onCancel}>
-        <div className="bg-[#1f1f1f] text-white p-6 rounded-lg w-[400px] z-50">
+      <div className="flex items-center justify-center z-50">
+        <div className="bg-[#1f1f1f] text-white p-6 rounded-lg w-[400px] z-100">
           <h2 className="text-xl font-bold mb-3">{title}</h2>
           <p className="mb-6">{message}</p>
           <div className="flex justify-end gap-4">
@@ -40,6 +40,6 @@ export default function ConfirmModal({
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
- Disable scrolling in the background when the backdrop is visible. And also handle the closing of the confirm modal when the backdrop is clicked.